### PR TITLE
Fix SQL statement bugs

### DIFF
--- a/app/Http/Controllers/Admin/FinishingMasukController.php
+++ b/app/Http/Controllers/Admin/FinishingMasukController.php
@@ -24,7 +24,7 @@ class FinishingMasukController extends Controller
         abort_if(Gate::denies('finishing_access'), Response::HTTP_FORBIDDEN, '403 Forbidden');
 
         if ($request->ajax()) {
-            $query = FinishingMasuk::select('no_spk', 'date', 'vendor_id')->distinct()->with(['vendor'])->latest();
+            $query = FinishingMasuk::select('no_spk', 'date', 'vendor_id','created_at')->distinct()->with(['vendor'])->latest();
 
             if (!empty($request->vendor)) {
                 $query->where('vendor_id', $request->vendor);


### PR DESCRIPTION
This pull request includes a change to the `index` function in the `FinishingMasukController` to enhance the data retrieved for the finishing access feature.

Enhancements to data retrieval:

* [`app/Http/Controllers/Admin/FinishingMasukController.php`](diffhunk://#diff-e0bd6eec6354feec809238720894713c607519cdacc64ba93b3fa32a8e2cc59dL27-R27): Added the `created_at` field to the select query in the `index` function to include the creation timestamp in the retrieved data.