### PR TITLE
Fix: Changed the having clause to use havingRaw

### DIFF
--- a/app/Http/Controllers/Admin/BillController.php
+++ b/app/Http/Controllers/Admin/BillController.php
@@ -467,7 +467,7 @@ class BillController extends Controller
             ->where('i.semester_id', $includeCurrent ? '<=' : '<', $semester)
             ->whereNull('i.deleted_at')
             ->groupBy('i.salesperson_id', 'i.semester_id', 's.name', 'r.total_return_goods_nominal', 'p.total_payments')
-            ->having('saldo_akhir', '>', 0)
+            ->havingRaw('saldo_akhir != 0')
             ->get();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "10.x-dev"
+            "dev-master": "11.x-dev"
         },
         "laravel": {
             "dont-discover": []


### PR DESCRIPTION
This pull request includes changes to `app/Http/Controllers/Admin/BillController.php` and `composer.json` to improve query handling and update the development branch alias.

Improvements to query handling:

* [`app/Http/Controllers/Admin/BillController.php`](diffhunk://#diff-e2fb3bbd6eb89ff381a83c29e7807c487aa55ae663044b9157d27193d475766aL470-R470): Changed the `having` clause to use `havingRaw` with `saldo_akhir != 0` to ensure more accurate filtering of results.

Development branch alias update:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L64-R64): Updated the `branch-alias` for `dev-master` from `10.x-dev` to `11.x-dev` to reflect the new development version.