### PR TITLE
fix: limit returned in getProducts to 50

### DIFF
--- a/app/Http/Controllers/Admin/BookVariantController.php
+++ b/app/Http/Controllers/Admin/BookVariantController.php
@@ -387,7 +387,7 @@ class BookVariantController extends Controller
         $query = BookVariant::where(function($q) use ($keyword) {
                     $q->where('code', 'LIKE', "%{$keyword}%")
                     ->orWhere('name', 'LIKE', "%{$keyword}%");
-                });
+                })->limit(50);
 
         if (!empty($jenjang)) {
             $query->where('jenjang_id', $jenjang);


### PR DESCRIPTION
This pull request introduces a small optimization to the `getProducts` method in `BookVariantController`. The change limits the number of results returned by the query to 50, improving performance for large datasets.