### PR TITLE
Add duplicate invoice check and null error handling in `generate` invoice

### DIFF
--- a/app/Models/BookVariant.php
+++ b/app/Models/BookVariant.php
@@ -92,7 +92,7 @@ class BookVariant extends Model implements HasMedia
         return $date->format('Y-m-d H:i:s');
     }
 
-    public function registerMediaConversions(Media $media = null): void
+    public function registerMediaConversions(?Media $media = null): void
     {
         $this->addMediaConversion('thumb')->fit('crop', 50, 50);
         $this->addMediaConversion('preview')->fit('crop', 120, 120);

--- a/resources/views/admin/invoices/generate.blade.php
+++ b/resources/views/admin/invoices/generate.blade.php
@@ -101,7 +101,7 @@
                                     Code : <strong>{{ $product->code }}</strong>
                                 </p>
                                 <p class="mb-0 text-sm">
-                                    Jenjang - Kurikulum : <strong>{{ $product->jenjang->name }} - {{ $product->book->cover->name }} - {{ $product->book->kurikulum->name }}</strong>
+                                    Jenjang - Kurikulum : <strong>{{ $product->jenjang->name }} - {{ $product->book ? $product->book->cover->name : $product->cover->name }} - {{ $product->book ? $product->book->kurikulum->name : $product->kurikulum->name }}</strong>
                                 </p>
                             </div>
                             <input type="hidden" name="delivery_items[]" value="{{ $item->id }}">


### PR DESCRIPTION
# What's Changed

### Invoice creation validation

* Added a check in `InvoiceController.php` to prevent creating an invoice if one already exists for the selected delivery order, displaying an error message and preserving form input.

### Code quality and type safety

* Updated the method signature in `BookVariant.php` to use nullable type-hinting for the `registerMediaConversions` parameter, improving type safety.

### Invoice generation view robustness

* Modified the product details display in `generate.blade.php` to handle cases where `book` may be null, falling back to using `cover` and `kurikulum` directly from the product if necessary.