### PR TITLE
Prevent Invoice with `jual` type to be generated more than one

### DIFF
--- a/app/Http/Controllers/Admin/InvoiceController.php
+++ b/app/Http/Controllers/Admin/InvoiceController.php
@@ -195,7 +195,7 @@ class InvoiceController extends Controller
         $semester = $delivery_order->semester_id;
         $salesperson = $delivery_order->salesperson_id;
 
-        $existingInvoice = Invoice::where('delivery_order_id', $validatedData['delivery'])->exists();
+        $existingInvoice = Invoice::where('delivery_order_id', $validatedData['delivery'])->where('type', 'jual')->exists();
         if ($existingInvoice) {
             return redirect()->back()
                 ->with('error-message', 'An invoice for this delivery order already exists.')

--- a/app/Models/Book.php
+++ b/app/Models/Book.php
@@ -51,7 +51,7 @@ class Book extends Model implements HasMedia
         return $date->format('Y-m-d H:i:s');
     }
 
-    public function registerMediaConversions(Media $media = null): void
+    public function registerMediaConversions(?Media $media = null): void
     {
         $this->addMediaConversion('thumb')->fit('crop', 50, 50);
         $this->addMediaConversion('preview')->fit('crop', 120, 120);


### PR DESCRIPTION
**Invoice creation logic:**

* Updated the check for existing invoices in `InvoiceController.php` to ensure only invoices of type `'jual'` are considered, preventing duplicate invoice creation for the same delivery order and type.

**Code consistency:**

* Refactored the `registerMediaConversions` method signature in `Book.php` to use the nullable type hint `?Media $media`, improving code clarity and consistency with modern PHP standards.