### PR TITLE
Optional automatic previous bill payments

### DIFF
--- a/app/Http/Controllers/Admin/PaymentController.php
+++ b/app/Http/Controllers/Admin/PaymentController.php
@@ -119,7 +119,7 @@ class PaymentController extends Controller
             'date' => 'required',
             'salesperson_id' => 'required',
             'semester_id' => 'required',
-            'pay_previous' => 'required|boolean',
+            'pay_previous' => 'required|in:0,1',
             'payment_method' => 'required',
             'bayar' => 'required|numeric|min:1',
             'diskon' => 'nullable|numeric',

--- a/app/Http/Controllers/Admin/PaymentController.php
+++ b/app/Http/Controllers/Admin/PaymentController.php
@@ -119,6 +119,7 @@ class PaymentController extends Controller
             'date' => 'required',
             'salesperson_id' => 'required',
             'semester_id' => 'required',
+            'pay_previous' => 'required|boolean',
             'payment_method' => 'required',
             'bayar' => 'required|numeric|min:1',
             'diskon' => 'nullable|numeric',
@@ -129,6 +130,7 @@ class PaymentController extends Controller
         $date = $validatedData['date'];
         $salesperson = $validatedData['salesperson_id'];
         $semester = $validatedData['semester_id'] ?? setting('current_semester');
+        $pay_previous = $validatedData['pay_previous'];
         $payment_method = $validatedData['payment_method'];
         $bayar = $validatedData['bayar'];
         $diskon = $validatedData['diskon'];
@@ -139,7 +141,7 @@ class PaymentController extends Controller
 
         DB::beginTransaction();
         try {
-            if ($before->count() > 0) {
+            if ($pay_previous && $before->count() > 0) {
                 foreach($before as $bill) {
                     if ($bayar > 0) {
                         $paid = ($bayar < $bill->piutang) ? $bayar : $bill->piutang;

--- a/resources/lang/en/cruds.php
+++ b/resources/lang/en/cruds.php
@@ -831,6 +831,8 @@ return [
             'salesperson_helper'    => ' ',
             'semester'              => 'Semester',
             'semester_helper'       => ' ',
+            'pay_previous'          => 'Bayar Tagihan Sebelumnya',
+            'pay_previous_helper'   => ' ',
             'paid'                  => 'Paid',
             'paid_helper'           => ' ',
             'discount'              => 'Discount',

--- a/resources/views/admin/payments/create.blade.php
+++ b/resources/views/admin/payments/create.blade.php
@@ -87,6 +87,16 @@
                         <span class="help-block">{{ trans('cruds.payment.fields.semester_helper') }}</span>
                     </div>
                 </div>
+                <div class="col-6">
+                    <div class="form-group">
+                        <label class="required" for="pay_previous">{{ trans('cruds.payment.fields.pay_previous') }}</label>
+                        <select class="form-control select2" name="pay_previous" id="pay_previous" required>
+                                <option value="1">Ya</option>
+                                <option value="0">Tidak</option>
+                        </select>
+                        <span class="help-block">{{ trans('cruds.payment.fields.pay_previous_helper') }}</span>
+                    </div>
+                </div>
                 <div class="col-12">
                     <div id="tagihan">
                     </div>


### PR DESCRIPTION
## What's Changed

**Payment processing enhancements:**

* Added `pay_previous` as a required boolean field in the payment validation rules in `PaymentController.php`, ensuring that the user's intent to pay previous bills is explicitly captured.
* Updated payment processing logic to only process previous bills if `pay_previous` is true, preventing unintended payments of outstanding bills.
* Included `pay_previous` in the set of validated data used during payment creation, making it available for business logic.

**User interface updates:**

* Added a new required select field for `pay_previous` in the payment creation form (`create.blade.php`), allowing users to choose whether to pay previous bills.
* Updated language resources in `cruds.php` to include labels and helper text for the new `pay_previous` field, ensuring proper display and translation.