### PR TITLE
Fix null reversal and transactions logic on payment

### DIFF
--- a/app/Http/Controllers/Admin/PaymentController.php
+++ b/app/Http/Controllers/Admin/PaymentController.php
@@ -161,17 +161,8 @@ class PaymentController extends Controller
                             'note' => '[AUTO] Pemindahan saldo ke ' . Semester::find($semester)->name . '.'
                         ]);
 
-                        TransactionService::createTransaction(
-                            $date,
-                            'Mencatat saldo negatif dengan No Kwitansi ' . $negativePayment->no_kwitansi,
-                            $salesperson,
-                            $bill->semester_id,
-                            'bayar',
-                            $negativePayment->id,
-                            $negativePayment->no_kwitansi,
-                            $bill->saldo_akhir,
-                            'credit'
-                        );
+                        TransactionService::createTransaction($date, 'Pembayaran dengan No Kwitansi ' . $negativePayment->no_kwitansi . ' dan Catatan :' . $note, $salesperson, $bill->semester_id, 'bayar', $negativePayment->id, $negativePayment->no_kwitansi, $bill->saldo_akhir, 'credit');
+                        TransactionService::createTransaction($date, 'Diskon Dari Pembayaran dengan No Kwitansi ' . $negativePayment->no_kwitansi . ' dan Catatan :' . $note, $salesperson, $bill->semester_id, 'potongan', $negativePayment->id, $negativePayment->no_kwitansi, 0, 'credit');
 
                         /**
                          * 2: Create positive payment to offset negative saldo
@@ -191,17 +182,8 @@ class PaymentController extends Controller
                             'note' => '[AUTO] Pemindahan saldo dari ' . $bill->semester_name . '.'
                         ]);
 
-                        TransactionService::createTransaction(
-                            $date,
-                            'Mengoreksi saldo negatif dengan No Kwitansi ' . $positivePayment->no_kwitansi,
-                            $salesperson,
-                            $bill->semester_id,
-                            'bayar',
-                            $positivePayment->id,
-                            $positivePayment->no_kwitansi,
-                            $positivePaid,
-                            'credit'
-                        );
+                        TransactionService::createTransaction($date, 'Pembayaran dengan No Kwitansi ' . $positivePayment->no_kwitansi . ' dan Catatan :' . $note, $salesperson, $bill->semester_id, 'bayar', $positivePayment->id, $positivePayment->no_kwitansi, $positivePaid, 'credit');
+                        TransactionService::createTransaction($date, 'Diskon Dari Pembayaran dengan No Kwitansi ' . $positivePayment->no_kwitansi . ' dan Catatan :' . $note, $salesperson, $bill->semester_id, 'potongan', $positivePayment->id, $positivePayment->no_kwitansi, 0, 'credit');
 
                         // Tidak kurangi $bayar — ini hanya koreksi saldo
                         continue;
@@ -226,17 +208,8 @@ class PaymentController extends Controller
                             'note' => $note
                         ]);
 
-                        TransactionService::createTransaction(
-                            $date,
-                            'Pembayaran dengan No Kwitansi ' . $payment->no_kwitansi,
-                            $salesperson,
-                            $bill->semester_id,
-                            'bayar',
-                            $payment->id,
-                            $payment->no_kwitansi,
-                            $paid,
-                            'credit'
-                        );
+                        TransactionService::createTransaction($date, 'Pembayaran dengan No Kwitansi ' . $payment->no_kwitansi . ' dan Catatan :' . $note, $salesperson, $semester, 'bayar', $payment->id, $payment->no_kwitansi, $bayar, 'credit');
+                        TransactionService::createTransaction($date, 'Diskon Dari Pembayaran dengan No Kwitansi ' . $payment->no_kwitansi . ' dan Catatan :' . $note, $salesperson, $semester, 'potongan', $payment->id, $payment->no_kwitansi, $diskon, 'credit');
 
                         $bayar -= $paid;
                     }

--- a/app/Services/TransactionService.php
+++ b/app/Services/TransactionService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Services;
 
 use Carbon\Carbon;
@@ -11,9 +12,17 @@ use App\Events\ProductionTransactionUpdated;
 
 class TransactionService
 {
-    public static function createTransaction($date, $description, $salesperson, $semester,
-        $type, $reference, $reference_no, $amount, $category)
-    {
+    public static function createTransaction(
+        $date,
+        $description,
+        $salesperson,
+        $semester,
+        $type,
+        $reference,
+        $reference_no,
+        $amount,
+        $category
+    ) {
         $transaction = Transaction::create([
             'date' => Carbon::now()->format('d-m-Y'),
             'description' => $description,
@@ -31,27 +40,37 @@ class TransactionService
         event(new TransactionUpdated($transaction));
     }
 
-    public static function editTransaction($date, $description, $salesperson, $semester,
-        $type, $reference, $reference_no, $amount, $category)
-    {
+    public static function editTransaction(
+        $date,
+        $description,
+        $salesperson,
+        $semester,
+        $type,
+        $reference,
+        $reference_no,
+        $amount,
+        $category
+    ) {
         $reversal = Transaction::where('type', $type)->where('reference_id', $reference)->orderBy('id', 'DESC')->first();
 
-        $reversal_transaction = Transaction::create([
-            'date' => Carbon::now()->format('d-m-Y'),
-            'description' => $reversal->description,
-            'salesperson_id' => $reversal->salesperson_id,
-            'semester_id' => $reversal->semester_id,
-            'type' => $type,
-            'reference_id' => $reference,
-            'reference_no' => $reversal->reference_no,
-            'transaction_date' => $date,
-            'amount' => -1 * $reversal->amount,
-            'category' => $category,
-            'status' => 0,
-            'reversal_of_id' => $reversal->id
-        ]);
+        if ($reversal) {
+            $reversal_transaction = Transaction::create([
+                'date' => Carbon::now()->format('d-m-Y'),
+                'description' => $reversal->description,
+                'salesperson_id' => $reversal->salesperson_id,
+                'semester_id' => $reversal->semester_id,
+                'type' => $type,
+                'reference_id' => $reference,
+                'reference_no' => $reversal->reference_no,
+                'transaction_date' => $date,
+                'amount' => -1 * $reversal->amount,
+                'category' => $category,
+                'status' => 0,
+                'reversal_of_id' => $reversal->id
+            ]);
 
-        event(new TransactionUpdated($reversal_transaction));
+            event(new TransactionUpdated($reversal_transaction));
+        }
 
         $transaction = Transaction::create([
             'date' => Carbon::now()->format('d-m-Y'),
@@ -70,9 +89,17 @@ class TransactionService
         event(new TransactionUpdated($transaction));
     }
 
-    public static function createProductionTransaction($date, $description, $vendor, $semester,
-        $type, $reference, $reference_no, $amount, $category)
-    {
+    public static function createProductionTransaction(
+        $date,
+        $description,
+        $vendor,
+        $semester,
+        $type,
+        $reference,
+        $reference_no,
+        $amount,
+        $category
+    ) {
         $transaction = ProductionTransaction::create([
             'date' => Carbon::now()->format('d-m-Y'),
             'description' => $description,
@@ -90,9 +117,17 @@ class TransactionService
         event(new ProductionTransactionUpdated($transaction));
     }
 
-    public static function editProductionTransaction($date, $description, $vendor, $semester,
-        $type, $reference, $reference_no, $amount, $category)
-    {
+    public static function editProductionTransaction(
+        $date,
+        $description,
+        $vendor,
+        $semester,
+        $type,
+        $reference,
+        $reference_no,
+        $amount,
+        $category
+    ) {
         $reversal = ProductionTransaction::where('type', $type)->where('reference_id', $reference)->where('semester_id', $semester)->orderBy('id', 'DESC')->first();
 
         ProductionTransaction::create([


### PR DESCRIPTION
What's Changed

**Payment transaction logic improvements:**

* The payment controller now creates two transactions for each payment: one for the payment itself and another for any associated discount, ensuring both are explicitly recorded. This applies to negative saldo corrections, positive saldo corrections, and regular payments. [[1]](diffhunk://#diff-6cff20eb90dbb58fccb1d3eb4f34d341f931dbbf30414047d11ecd42ea84e8ecL164-R165) [[2]](diffhunk://#diff-6cff20eb90dbb58fccb1d3eb4f34d341f931dbbf30414047d11ecd42ea84e8ecL194-R186) [[3]](diffhunk://#diff-6cff20eb90dbb58fccb1d3eb4f34d341f931dbbf30414047d11ecd42ea84e8ecL229-R212)

**Service layer refactoring:**

* The `TransactionService` and related methods (`createTransaction`, `editTransaction`, `createProductionTransaction`, `editProductionTransaction`) are refactored for better readability, using multi-line parameter formatting and improved conditional logic for reversals. [[1]](diffhunk://#diff-46521d3b2a11c92f4165c3132b6f39b4c184e548686d826a4ed4abc8bb9e02e5L14-R25) [[2]](diffhunk://#diff-46521d3b2a11c92f4165c3132b6f39b4c184e548686d826a4ed4abc8bb9e02e5L34-R56) [[3]](diffhunk://#diff-46521d3b2a11c92f4165c3132b6f39b4c184e548686d826a4ed4abc8bb9e02e5R73) [[4]](diffhunk://#diff-46521d3b2a11c92f4165c3132b6f39b4c184e548686d826a4ed4abc8bb9e02e5L73-R102) [[5]](diffhunk://#diff-46521d3b2a11c92f4165c3132b6f39b4c184e548686d826a4ed4abc8bb9e02e5L93-R130)
* Conditional logic is added in `editTransaction` to only create a reversal transaction if one exists, preventing unnecessary records.

These changes result in clearer transaction records and more maintainable service code.