### PR TITLE
Add Bulk Import Feature for Stock Adjustments via Excel/CSV

### DIFF
--- a/app/Imports/StockAdjustmentImport.php
+++ b/app/Imports/StockAdjustmentImport.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Imports;
+
+use App\Models\StockAdjustment;
+use App\Models\StockAdjustmentDetail;
+use App\Services\StockService;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Maatwebsite\Excel\Concerns\ToCollection;
+use Maatwebsite\Excel\Concerns\WithHeadingRow;
+use RealRashid\SweetAlert\Facades\Alert;
+
+class StockAdjustmentImport implements ToCollection, WithHeadingRow
+{
+    private $adjustment;
+
+    public function __construct(int $adjustment)
+    {
+        $this->adjustment = StockAdjustment::find($adjustment);
+    }
+
+    public function collection(Collection $rows)
+    {
+        $adjustment = $this->adjustment;
+        $type = $adjustment->type;
+        $date = $adjustment->date;
+
+        foreach ($rows as $row) {
+            $product    = $row['product_id'];
+            $quantity   = $row['quantity'];
+
+            $multiplier = ($adjustment->operation == 'increase') ? 1 : -1;
+
+            if ($type === 'book') {
+                StockAdjustmentDetail::create([
+                    'product_id'            => $product,
+                    'stock_adjustment_id'   => $adjustment->id,
+                    'quantity'              => $quantity,
+                ]);
+
+                StockService::createMovement('adjustment', 'adjustment', $adjustment->id, $date, $product, $multiplier * $quantity);
+                StockService::updateStock($product, $multiplier * $quantity);
+            } elseif ($type === 'material') {
+                StockAdjustmentDetail::create([
+                    'material_id'           => $product,
+                    'stock_adjustment_id'   => $adjustment->id,
+                    'quantity'              => $quantity,
+                ]);
+
+                StockService::createMovementMaterial('adjustment', 'adjustment', $adjustment->id, $date, $product, $multiplier * $quantity);
+                StockService::updateStockMaterial($product, $multiplier * $quantity);
+            }
+        }
+    }
+}

--- a/resources/views/admin/stockAdjustments/index.blade.php
+++ b/resources/views/admin/stockAdjustments/index.blade.php
@@ -9,9 +9,119 @@
             <a class="btn btn-warning" href="{{ route('admin.stock-adjustments.create', ['type' => 'material']) }}">
                 {{ trans('global.add') }} {{ trans('cruds.stockAdjustment.title_singular') }} Material
             </a>
+            <button class="btn btn-primary" data-toggle="modal" data-target="#importModal">
+                Import
+            </button>
         </div>
     </div>
 @endcan
+
+<div class="modal fade" id="importModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title" id="myModalLabel">Import Excel or CSV File</h4>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body">
+                <div class='row'>
+                    <div class='col-md-12'>
+
+                        <form class="form-horizontal" method="POST" action="{{ route('admin.stock-adjustments.import') }}" enctype="multipart/form-data">
+                            {{ csrf_field() }}
+
+                            <div class="row">
+                                <div class="col-4">
+                                    <div class="form-group">
+                                        <label class="required" for="date">{{ trans('cruds.stockAdjustment.fields.date') }}</label>
+                                        <input class="form-control date {{ $errors->has('date') ? 'is-invalid' : '' }}" type="text" name="date" id="date" value="{{ old('date', $today) }}" required>
+                                        @if($errors->has('date'))
+                                            <span class="text-danger">{{ $errors->first('date') }}</span>
+                                        @endif
+                                        <span class="help-block">{{ trans('cruds.stockAdjustment.fields.date_helper') }}</span>
+                                    </div>
+                                </div>
+                                <div class="col-4">
+                                    <div class="form-group">
+                                        <label class="required">{{ trans('cruds.stockAdjustment.fields.operation') }}</label>
+                                        <select class="form-control {{ $errors->has('operation') ? 'is-invalid' : '' }}" name="operation" id="operation" required>
+                                            <option value disabled {{ old('operation', null) === null ? 'selected' : '' }}>{{ trans('global.pleaseSelect') }}</option>
+                                            @foreach(App\Models\StockAdjustment::OPERATION_SELECT as $key => $label)
+                                                <option value="{{ $key }}" {{ old('operation', '') === (string) $key ? 'selected' : '' }}>{{ $label }}</option>
+                                            @endforeach
+                                        </select>
+                                        @if($errors->has('operation'))
+                                            <span class="text-danger">{{ $errors->first('operation') }}</span>
+                                        @endif
+                                        <span class="help-block">{{ trans('cruds.stockAdjustment.fields.operation_helper') }}</span>
+                                    </div>
+                                </div>
+                                <div class="col-4">
+                                    <div class="form-group">
+                                        <label class="required">{{ trans('cruds.stockAdjustment.fields.type') }}</label>
+                                        <select class="form-control {{ $errors->has('type') ? 'is-invalid' : '' }}" name="type" id="type" required>
+                                            <option value disabled {{ old('type', null) === null ? 'selected' : '' }}>{{ trans('global.pleaseSelect') }}</option>
+                                            @foreach(App\Models\StockAdjustment::TYPE_SELECT as $key => $label)
+                                                <option value="{{ $key }}" {{ old('type', '') === (string) $key ? 'selected' : '' }}>{{ $label }}</option>
+                                            @endforeach
+                                        </select>
+                                        @if($errors->has('type'))
+                                            <span class="text-danger">{{ $errors->first('type') }}</span>
+                                        @endif
+                                        <span class="help-block">{{ trans('cruds.stockAdjustment.fields.type_helper') }}</span>
+                                    </div>
+                                </div>
+                                <div class="col-12">
+                                    <div class="form-group">
+                                        <label class="required" for="reason">{{ trans('cruds.stockAdjustment.fields.reason') }}</label>
+                                        <input class="form-control {{ $errors->has('reason') ? 'is-invalid' : '' }}" type="text" name="reason" id="reason" value="{{ old('reason', '') }}" required>
+                                        @if($errors->has('reason'))
+                                            <span class="text-danger">{{ $errors->first('reason') }}</span>
+                                        @endif
+                                        <span class="help-block">{{ trans('cruds.stockAdjustment.fields.reason_helper') }}</span>
+                                    </div>
+                                </div>
+                                <div class="col-12">
+                                    <div class="form-group">
+                                        <label for="note">{{ trans('cruds.stockAdjustment.fields.note') }}</label>
+                                        <textarea class="form-control {{ $errors->has('note') ? 'is-invalid' : '' }}" name="note" id="note">{{ old('note') }}</textarea>
+                                        @if($errors->has('note'))
+                                            <span class="text-danger">{{ $errors->first('note') }}</span>
+                                        @endif
+                                        <span class="help-block">{{ trans('cruds.stockAdjustment.fields.note_helper') }}</span>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="form-group{{ $errors->has('import_file') ? ' has-error' : '' }}">
+                                <label for="import_file" class="col-md-4 control-label">Excel or CSV File to Import</label>
+
+                                <div class="col-md-6">
+                                    <input id="import_file" type="file" class="form-control-file" name="import_file" required>
+
+                                    @if($errors->has('import_file'))
+                                        <span class="help-block">
+                                            <strong>{{ $errors->first('import_file') }}</strong>
+                                        </span>
+                                    @endif
+                                </div>
+                            </div>
+
+                            <div class="form-group">
+                                <div class="col-md-8 col-md-offset-4">
+                                    <button type="submit" class="btn btn-primary">
+                                        Import
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
 <div class="card">
     <div class="card-header">
         {{ trans('cruds.stockAdjustment.title_singular') }} {{ trans('global.list') }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -170,6 +170,7 @@ Route::group(['prefix' => 'admin', 'as' => 'admin.', 'namespace' => 'Admin', 'mi
 
     // Stock Adjustment
     Route::delete('stock-adjustments/destroy', 'StockAdjustmentController@massDestroy')->name('stock-adjustments.massDestroy');
+    Route::post('stock-adjustments/import', 'StockAdjustmentController@import')->name('stock-adjustments.import');
     Route::resource('stock-adjustments', 'StockAdjustmentController');
 
     // Materials


### PR DESCRIPTION
## What's Changed:

**Stock Adjustment Import Feature:**

* Added a new `import` method to `StockAdjustmentController` that handles file uploads, validates the input, creates a stock adjustment record, and processes the import using the new `StockAdjustmentImport` class.
* Created the `StockAdjustmentImport` class in `app/Imports/StockAdjustmentImport.php` to process each row of the uploaded file, creating corresponding `StockAdjustmentDetail` records and updating stock levels via `StockService`.

**UI Enhancements:**

* Updated `resources/views/admin/stockAdjustments/index.blade.php` to add an "Import" button and modal form for uploading Excel/CSV files, including fields for date, operation, type, reason, note, and file selection.
* Modified the controller to pass the current date to the index view for use in the import modal. [[1]](diffhunk://#diff-744fdf960118e15418e1b60d367d5b5722d038e85ceb0b1a54b45103663e1581R20-R29) [[2]](diffhunk://#diff-744fdf960118e15418e1b60d367d5b5722d038e85ceb0b1a54b45103663e1581L59-R63)

**Routing:**

* Added a new POST route `stock-adjustments/import` to handle import requests.